### PR TITLE
Completion results, fzf error

### DIFF
--- a/lua/cmp2lsp/init.lua
+++ b/lua/cmp2lsp/init.lua
@@ -106,10 +106,8 @@ M.setup = function(opts)
           ))
         then
           source:complete(abstracted_context, function(items)
-            if #items > 0 then
-              for _, item in ipairs(items) do
-                table.insert(response, item)
-              end
+            for _, item in ipairs(items) do
+              table.insert(response, item)
             end
           end)
         end

--- a/lua/cmp2lsp/init.lua
+++ b/lua/cmp2lsp/init.lua
@@ -122,8 +122,11 @@ M.setup = function(opts)
 
   vim.api.nvim_create_autocmd("FileType", {
     pattern = "*",
-    callback = function()
-      M.start_lsp(handlers)
+    callback = function(event)
+      local filetype = vim.api.nvim_get_option_value("filetype", { buf = event.buf })
+      if filetype ~= "fzf" then
+        M.start_lsp(handlers)
+      end
     end,
   })
 end

--- a/lua/cmp2lsp/init.lua
+++ b/lua/cmp2lsp/init.lua
@@ -107,14 +107,16 @@ M.setup = function(opts)
         then
           source:complete(abstracted_context, function(items)
             if #items > 0 then
-              table.insert(response, items)
+              for _, item in ipairs(items) do
+                table.insert(response, item)
+              end
             end
           end)
         end
         ::continue::
       end
 
-      callback(nil, vim.iter(response):flatten(1):totable())
+      callback(nil, response)
     end,
   }
 


### PR DESCRIPTION
probably fixes #2

for some reason, the vim.iter() approach didn't create the correct response and autocompletion items weren't showing up (from this plugin: https://github.com/adalessa/laravel.nvim/tree/development)

This also fixes an issue where disabling .gitignore or switching between regex and fuzzy searching in fzf would error and make fzf unusable.